### PR TITLE
solved manifest issue when using with nexus3 repository

### DIFF
--- a/docker_pull.py
+++ b/docker_pull.py
@@ -928,11 +928,9 @@ class ImageFetcher:
         manifest = manifest_resp.json()
 
         if not img.manifest_digest:
-            if manifest["mediaType"] == self.__IMG_MANIFEST_FORMAT or \
-                    manifest["mediaType"] == self.__OCI_IMAGE_MANIFEST_FORMAT:
+            if manifest["mediaType"] in [self.__IMG_MANIFEST_FORMAT, self.__OCI_IMAGE_MANIFEST_FORMAT]:
                 self._pull_from_manifest(img, manifest)
-            elif manifest["mediaType"] == self.__LST_MTYPE or \
-                    manifest["mediaType"] == self.__OCI_IMAGE_INDEX_FORMAT:
+            elif manifest["mediaType"] in [self.__LST_MTYPE, self.__OCI_IMAGE_INDEX_FORMAT]:
                 self._pull_from_mainfest_list(img, manifest, platform)
         else:
             img_name_n = img.image.replace("/", "_")


### PR DESCRIPTION
I discovered an issue while pulling images from a private Nexus3 repository, where the mediatype was not handled properly.
referred the oci docs and docker docs, i solved the issue.

referred docs : 
https://github.com/opencontainers/image-spec/blob/main/media-types.md
https://distribution.github.io/distribution/spec/manifest-v2-2/

i hope it would help your repo, as much as your repo helped me.